### PR TITLE
Use a dark scrollbar in dark mode

### DIFF
--- a/webgl/lessons/resources/lesson.css
+++ b/webgl/lessons/resources/lesson.css
@@ -446,6 +446,9 @@ pre.prettyprint, code.prettyprint {
 }
 
 @media (prefers-color-scheme: dark) {
+  html {
+    scrollbar-color: hsl(0, 0%, 34%) hsl(0, 0%, 13%);
+  }
   body {
     background: #333;
     color: #CCC;
@@ -486,10 +489,10 @@ pre.prettyprint, code.prettyprint {
     background: #222;
   }
   .lesson-main>blockquote {
-      background-color: #1b1b44;
+    background-color: #1b1b44;
   }
   table.vertex_table th {
-      background-color: #348;
+    background-color: #348;
   }
   div.webgl_bottombar {
     background-color: #1b1b44;

--- a/webgl/lessons/resources/lesson.css
+++ b/webgl/lessons/resources/lesson.css
@@ -447,7 +447,7 @@ pre.prettyprint, code.prettyprint {
 
 @media (prefers-color-scheme: dark) {
   html {
-    scrollbar-color: hsl(0, 0%, 34%) hsl(0, 0%, 13%);
+    scrollbar-color: hsl(0, 0%, 35%) hsl(0, 0%, 13%);
   }
   body {
     background: #333;


### PR DESCRIPTION
Recoloring the scrollbar to fit the new dark mode, small but effective.
The `scrollbar-color` property is so far only supported by Firefox (since version 64).

Side question: Does the duplicate check for dark mode in the dark mode block on [this line](https://github.com/gfxfundamentals/webgl2-fundamentals/blob/master/webgl/lessons/resources/lesson.css#L463) of lesson.css serve any purpose? lol