### PR TITLE
Add info about WebGL2 support

### DIFF
--- a/webgl/lessons/webgl-getting-webgl2.md
+++ b/webgl/lessons/webgl-getting-webgl2.md
@@ -2,12 +2,15 @@ Title: How to use WebGL2
 Description: Getting a WebGL2 capable browser
 TOC: How to use WebGL2
 
-As of January 27, 2016 WebGL2 is available by default in Firefox 51
-and Chrome 56.
+As of May 2020, WebGL2 is available in the latest versions of Chrome, Edge,
+Firefox and Opera.
+
+This accounts for over 70% of all internet users, according to
+[Can I use...](https://caniuse.com/#feat=webgl2)
 
 Note that Safari claims to have WebGL2 as an experiment but that is mostly
 an exaggeration. AFAICT all Safari did was enable GLSL ES 3.00 shaders. Looking
-at [the WebKit source code](https://svn.webkit.org/repository/webkit/trunk/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp) 
+at [the WebKit source code](https://svn.webkit.org/repository/webkit/trunk/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp)
 pretty much all of the WebGL2 specific API functions
 are marked as **NOT IMPLEMENTED** as of November 2019.
 
@@ -59,4 +62,3 @@ RefPtr<WebGLSampler> WebGL2RenderingContext::createSampler()
     return nullptr;
 }
 ```
-


### PR DESCRIPTION
Updates the information on the getting WebGL2 page with newer statistics and a link to the [Can I Use...](https://caniuse.com/) site.