### PR TITLE
Fix spelling error

### DIFF
--- a/webgl/lessons/webgl-gpgpu.md
+++ b/webgl/lessons/webgl-gpgpu.md
@@ -113,7 +113,7 @@ mapDst(dst, multBy2(src));
 // dst is now [2, 4, 6, 8, 10, 12];
 ```
 
-## In WebGL the index or ID of the pixel who's value you're being asked to provide is called `gl_FragCoord`
+## In WebGL the index or ID of the pixel whose value you're being asked to provide is called `gl_FragCoord`
 
 ```js
 let outColor;


### PR DESCRIPTION
1. belonging to or associated with which person.
"whose round is it?"
2. of whom or which (used to indicate that the following noun belongs to or is associated with the person or thing mentioned in the previous clause).
"it's a pixel whose color is red"
