### PR TITLE
fixed typos / code snippets

### DIFF
--- a/webgl/lessons/ko/webgl-less-code-more-fun.md
+++ b/webgl/lessons/ko/webgl-less-code-more-fun.md
@@ -340,7 +340,7 @@ objects.forEach(function(object) {
        indices:  { numComponents: 3, data: [0, 1, 2, 1, 2, 3],                       },
     };
 
-    var bufferInfo = twgl.createBufferInfoFromTypedArray(gl, arrays);
+    var bufferInfo = twgl.createBufferInfoFromArrays(gl, arrays);
     var vao = twgl.createVAOFromBufferInfo(gl, setters, bufferInfo);
 
 렌더링 시점에서 `gl.drawArrays` 대신에 `gl.drawElements`를 호출하면 됩니다.

--- a/webgl/lessons/webgl-data-textures.md
+++ b/webgl/lessons/webgl-data-textures.md
@@ -299,7 +299,7 @@ WebGL: INVALID_OPERATION: texImage2D: ArrayBufferView not big enough for request
 
 It turns out there's a kind of obscure setting in WebGL left
 over from when OpenGL was first created. Computers sometimes
-go faster then data is a certain size. For example it can
+go faster when data is a certain size. For example it can
 be faster to copy 2, 4, or 8 bytes at a time instead of 1 at a time.
 WebGL defaults to using 4 bytes at a time so it expects each
 row of data to be a multiple of 4 bytes (except for the last row).

--- a/webgl/lessons/webgl-less-code-more-fun.md
+++ b/webgl/lessons/webgl-less-code-more-fun.md
@@ -339,7 +339,7 @@ with your `indices` so when you bind that VAO you can call
        indices:  { numComponents: 3, data: [0, 1, 2, 1, 2, 3],                       },
     };
 
-    var bufferInfo = twgl.createBufferInfoFromTypedArray(gl, arrays);
+    var bufferInfo = twgl.createBufferInfoFromArrays(gl, arrays);
     var vao = twgl.createVAOFromBufferInfo(gl, setters, bufferInfo);
 
 and at render time we can call `gl.drawElements` instead of `gl.drawArrays`.

--- a/webgl/lessons/webgl-pulling-vertices.md
+++ b/webgl/lessons/webgl-pulling-vertices.md
@@ -188,7 +188,7 @@ const positionIndexUVIndexBuffer = gl.createBuffer();
 // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = positionBuffer)
 gl.bindBuffer(gl.ARRAY_BUFFER, positionIndexUVIndexBuffer);
 // Put the position and texcoord indices in the buffer
-gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positionIndexUVIndex), gl.STATIC_DRAW);
+gl.bufferData(gl.ARRAY_BUFFER, new Uint32Array(positionIndexUVIndex), gl.STATIC_DRAW);
 ```
 
 and setup the attribute

--- a/webgl/lessons/webgl-render-to-texture.md
+++ b/webgl/lessons/webgl-render-to-texture.md
@@ -65,7 +65,7 @@ framebuffers reference whatever framebuffer is bound there.
 With our framebuffer bound, anytime we call `gl.clear`, `gl.drawArrays`, or `gl.drawElements` WebGL
 would render to our texture instead of the canvas.
 
-Let's take are previous rendering code and make it a function so we can call it twice.
+Let's take our previous rendering code and make it a function so we can call it twice.
 Once to render to the texture and again to render to the canvas.
 
 ```

--- a/webgl/lessons/zh_cn/webgl-less-code-more-fun.md
+++ b/webgl/lessons/zh_cn/webgl-less-code-more-fun.md
@@ -333,7 +333,7 @@ objects.forEach(function(object) {
        indices:  { numComponents: 3, data: [0, 1, 2, 1, 2, 3],                       },
     };
 
-    var bufferInfo = twgl.createBufferInfoFromTypedArray(gl, arrays);
+    var bufferInfo = twgl.createBufferInfoFromArrays(gl, arrays);
     var vao = twgl.createVAOFromBufferInfo(gl, setters, bufferInfo);
 
 在渲染时将调用 `gl.drawElements` 代替 `gl.drawArrays`。


### PR DESCRIPTION
- correct `twgl` function in `webgl-less-code-more-fun.md`
  (and translations)
- correct array type for `positionIndexUVIndex`
- typo in `webgl-data-textures.md`
- typo in `webgl-render-to-texture.md`