### PR TITLE
Change from webgl1 to webgl2 syntax

### DIFF
--- a/webgl/lessons/webgl-instanced-drawing.md
+++ b/webgl/lessons/webgl-instanced-drawing.md
@@ -227,9 +227,11 @@ precision highp float;
 +// Passed in from the vertex shader.
 +in vec4 v_color;
 
+out vec4 outColor;
+
 void main() {
--  gl_FragColor = color;
-+  gl_FragColor = v_color;
+-  outColor = color;
++  outColor = v_color;
 }
 `;  
 ```


### PR DESCRIPTION
This was probably left there due to coping from the old tutorial.