### PR TITLE
Fix description about compressed textures

### DIFF
--- a/webgl/lessons/webgl2-whats-new.md
+++ b/webgl/lessons/webgl2-whats-new.md
@@ -132,18 +132,15 @@ In WebGL1 there are various compressed texture formats
 that are hardware dependent. S3TC was basically desktop only.
 PVTC was iOS only, etc.
 
-In WebGL2 these formats are supposed to be supported everywhere:
+In WebGL2 at least one suite of compressed texture formats are supported.
 
-*   `COMPRESSED_R11_EAC RED`
-*   `COMPRESSED_SIGNED_R11_EAC RED`
-*   `COMPRESSED_RG11_EAC RG`
-*   `COMPRESSED_SIGNED_RG11_EAC RG`
-*   `COMPRESSED_RGB8_ETC2 RGB`
-*   `COMPRESSED_SRGB8_ETC2 RGB`
-*   `COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 RGBA`
-*   `COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 RGBA`
-*   `COMPRESSED_RGBA8_ETC2_EAC RGBA`
-*   `COMPRESSED_SRGB8_ALPHA8_ETC2_EAC`
+* WEBGL_compressed_texture_etc AND/OR
+* (
+  * WEBGL_compressed_texture_s3tc AND
+  * WEBGL_compressed_texture_s3tc_srgb AND
+  * EXT_texture_compression_rgtc
+  
+  )
 
 ## Uniform Buffer Objects
 


### PR DESCRIPTION
In https://registry.khronos.org/webgl/specs/latest/2.0/#5.37
> OpenGL ES 3.0 requires support for the following ETC2 and EAC compressed texture formats: COMPRESSED_R11_EAC, COMPRESSED_SIGNED_R11_EAC, COMPRESSED_RG11_EAC, COMPRESSED_SIGNED_RG11_EAC, COMPRESSED_RGB8_ETC2, COMPRESSED_SRGB8_ETC2, COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2, COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2, COMPRESSED_RGBA8_ETC2_EAC, and COMPRESSED_SRGB8_ALPHA8_ETC2_EAC.
> 
> These texture formats are not supported by default in WebGL 2.0.

In https://registry.khronos.org/webgl/specs/latest/2.0/#5.37
<img width="655" alt="image" src="https://user-images.githubusercontent.com/800043/212272436-544a2610-10f5-4fba-8abc-37919a8429fd.png">
