### PR TITLE
Example cleanup - remove duplicate call to bindBuffer in Image Processing section

### DIFF
--- a/webgl/lessons/webgl-2d-translation.md
+++ b/webgl/lessons/webgl-2d-translation.md
@@ -56,7 +56,7 @@ passed to `setRectangle` right? Here's a sample based on our
 +    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
 *    setRectangle(gl, translation[0], translation[1], width, height);
 
-    // Set a the color.
+    // Set the color.
     gl.uniform4fv(colorLocation, color);
 
     // Draw the rectangle.

--- a/webgl/webgl-2d-image-processing.html
+++ b/webgl/webgl-2d-image-processing.html
@@ -167,9 +167,13 @@ function render(image) {
   // Turn on the attribute
   gl.enableVertexAttribArray(positionAttributeLocation);
 
-  // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = positionBuffer)
+  // Bind the position buffer so gl.bufferData that will be called
+  // in setRectangle puts data in the position buffer
   gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
 
+  // Set a rectangle the same size as the image.
+  setRectangle(gl, 0, 0, image.width, image.height);
+  
   // Tell the attribute how to get data out of positionBuffer (ARRAY_BUFFER)
   var size = 2;          // 2 components per iteration
   var type = gl.FLOAT;   // the data is 32bit floats
@@ -260,12 +264,6 @@ function render(image) {
         gl.FRAMEBUFFER, attachmentPoint, gl.TEXTURE_2D, texture, mipLevel);
   }
 
-  // Bind the position buffer so gl.bufferData that will be called
-  // in setRectangle puts data in the position buffer
-  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-
-  // Set a rectangle the same size as the image.
-  setRectangle(gl, 0, 0, image.width, image.height);
 
   // Define several convolution kernels
   var kernels = {

--- a/webgl/webgl-2d-image.html
+++ b/webgl/webgl-2d-image.html
@@ -114,8 +114,12 @@ function render(image) {
   // Turn on the attribute
   gl.enableVertexAttribArray(positionAttributeLocation);
 
-  // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = positionBuffer)
+  // Bind the position buffer so gl.bufferData that will be called
+  // in setRectangle puts data in the position buffer
   gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+
+  // Set a rectangle the same size as the image.
+  setRectangle(gl, 0, 0, image.width, image.height);
 
   // Tell the attribute how to get data out of positionBuffer (ARRAY_BUFFER)
   var size = 2;          // 2 components per iteration
@@ -200,13 +204,6 @@ function render(image) {
 
   // Tell the shader to get the texture from texture unit 0
   gl.uniform1i(imageLocation, 0);
-
-  // Bind the position buffer so gl.bufferData that will be called
-  // in setRectangle puts data in the position buffer
-  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-
-  // Set a rectangle the same size as the image.
-  setRectangle(gl, 0, 0, image.width, image.height);
 
   // Draw the rectangle.
   var primitiveType = gl.TRIANGLES;


### PR DESCRIPTION
Reading the examples from https://webgl2fundamentals.org/webgl/lessons/webgl-image-processing.html I noticed that  `bindBuffer(gl.ARRAY_BUFFER, positionBuffer)` is called in two spots:

1. before `gl.vertexAttribPointer(...)`
2. before `setRectangle(...)`

This PR "merges" the second `bindBuffer()` with the first one.  
Seems to work but I'm still learning WebGL so maybe I missed something obvious.