### PR TITLE
Fix typo in point lighting example.

### DIFF
--- a/webgl/lessons/webgl-3d-lighting-point.md
+++ b/webgl/lessons/webgl-3d-lighting-point.md
@@ -341,7 +341,7 @@ and
     +  // set the light color
     +  gl.uniform3fv(lightColorLocation, normalize([1, 0.6, 0.6]));  // red light
     +  // set the specular color
-    +  gl.uniform3fv(specularColorLocation, normalize([1, 0.6, 0.6]));  // red light
+    +  gl.uniform3fv(specularColorLocation, normalize([1, 0.2, 0.2]));  // red light
 
 {{{example url="../webgl-3d-lighting-point-color.html" }}}
 

--- a/webgl/lessons/zh_cn/webgl-3d-lighting-point.md
+++ b/webgl/lessons/zh_cn/webgl-3d-lighting-point.md
@@ -320,7 +320,7 @@ TOC: 点光源
     +  // 设置光照颜色
     +  gl.uniform3fv(lightColorLocation, normalize([1, 0.6, 0.6]));  // red light
     +  // 设置高光颜色
-    +  gl.uniform3fv(specularColorLocation, normalize([1, 0.6, 0.6]));  // red light
+    +  gl.uniform3fv(specularColorLocation, normalize([1, 0.2, 0.2]));  // red light
 
 {{{example url="../webgl-3d-lighting-point-color.html" }}}
 


### PR DESCRIPTION
In `webgl-3d-lighting-point-color.html` the specular color is set to [1.0, 0.2, 0.2]