### PR TITLE
Fix parsing issue with `missing` in korean

### DIFF
--- a/webgl/lessons/ko/langinfo.hanson
+++ b/webgl/lessons/ko/langinfo.hanson
@@ -8,12 +8,9 @@
   commentSectionHeader: `
     <div>이슈나 버그가 있나요? <a href="https://github.com/greggman/webgl2-fundamentals/issues">깃헙에서 이슈 만들기</a>.</div>
   `,
-  missing: `
-    죄송합니다. 이 문서는 아직 한국어로 번역되지 않았습니다.
-
-    [번역을 도와주세요!](https://github.com/greggman/webgl-fundamentals)! 😄
-
-    [원문 보기]({{{origLink}}}).
+  missing: `죄송합니다. 이 문서는 아직 한국어로 번역되지 않았습니다.
+    \n[번역을 도와주세요!](https://github.com/greggman/webgl-fundamentals) 😄
+    \n[원문 보기]({{{origLink}}})
   `,
   contribTemplate: '<a href="${html_url}"><img src="${avatar_url}"> ${login}</a>님, <br>당신의 <a href="https://github.com/${owner}/${repo}/commits?author=${login}">${contributions} 기여</a>에 감사드립니다.',
   toc: '목차',


### PR DESCRIPTION
## as-is:
<img width="760" alt="image" src="https://github.com/gfxfundamentals/webgl2-fundamentals/assets/54790378/9ff62b59-9868-4b12-bd26-93ce3e029ab9">

## to-be:
<img width="470" alt="image" src="https://github.com/gfxfundamentals/webgl2-fundamentals/assets/54790378/ed9f7e49-06bc-40b6-a3a4-acec92773a5c">
