### PR TITLE
Adding "Getting Started" information to the index page

### DIFF
--- a/webgl/lessons/index.md
+++ b/webgl/lessons/index.md
@@ -7,9 +7,11 @@ They are NOT old rehashed out of date OpenGL articles like many others on the ne
 They are entirely new, discarding the old out of date ideas and bringing you
 to a full understanding of what WebGL really is and how it really works.
 
+# Coming from WebGL 1.0?
+
 These articles are specifically about WebGL2.
 If you are interested in WebGL 1.0 please [go here](https://webglfundamentals.org).
-If you are already familar with WebGL1 you might want to look at these articles.
+If you are already familar with WebGL1 you might want to look at these articles:
 
 <ul>
 <li><a href="/webgl/lessons/webgl-getting-webgl2.html">How to use WebGL2</a></li>
@@ -18,16 +20,19 @@ If you are already familar with WebGL1 you might want to look at these articles.
 <li><a href="/webgl/lessons/webgl1-to-webgl2-fundamentals.html">Differences from WebGLFundamentals.org to WebGL2Fundamentals.org</a></li>
 </ul>
 
+# Getting Started
+
+To start with WebGL2 you first need to set up a development environment. If you already have a workflow for creating web projects (e.g. with VS Code) you can use that or take a look at the [Setup and Installation](/webgl/lessons/webgl-setup-and-installation.html).
+
+You will encounter code and functions that is used throughout the different lessons. To make working with this repeating code easier, it can be bundled into a boilerplate and imported into your lessons. See [Boilerplate](/webgl/lessons/webgl-boilerplate.html) for details.  
+If you set up your environment, feel free to get take a look at the [Fundamentals](/webgl/lessons/webgl-fundamentals.html)!
+
 # Table of Contents
 
 {{{include "webgl/lessons/toc.html"}}}
-
 
 <!--
 
 {{{table_of_contents}}}
 
 -->
-
-
-


### PR DESCRIPTION
Hello,

I am currently learning WebGL2 with the help of the website, but felt the index page was missing a starting point for beginners.
As the "Fundamentals" articles requires having a setup and the boilerplate code (the function `webglUtils.resizeCanvasToDisplaySize` is mentioned in there without a previous mention of this boilerplate code and can confuse users where it comes from) it would be good to show at least the order of the 3 articles.

This PR adds a new section to the index page with more information on where to start.

# Previously
<img src="https://github.com/gfxfundamentals/webgl2-fundamentals/assets/29582303/9d08413e-88e0-4221-99d7-772d7fe4f61b" width="33%">


# With Getting Started
<img src=https://github.com/gfxfundamentals/webgl2-fundamentals/assets/29582303/4647ccf4-dc95-45e9-8af2-f03e27e8e4f8 width="33%">



